### PR TITLE
Added functionality for fold/unfold all.

### DIFF
--- a/main.js
+++ b/main.js
@@ -16,6 +16,8 @@ $(function() {
   const spaceMap = new Map();
   const pairs = new Map();
   const stack = [];
+  const plusKeys = [107, 187];
+  const minusKeys = [109, 189];
 
   const countInitialWhiteSpace = arr => {
     const getWhiteSpaceIndex = i => {
@@ -68,6 +70,26 @@ $(function() {
       $(codeLines[start - 1]).find('.ellipsis').remove();
     }
   }
+  
+  const foldAll = () => {
+    $('.collapser:not(:first)').addClass('sideways');
+    
+    pairs.forEach((end, start) => {
+      if (start !== 0) {
+        toggleCode('hide', start + 1, end + 1);
+      }
+    });
+  };
+
+  const unfoldAll = () => {
+    $('.collapser:not(:first)').removeClass('sideways');
+
+    pairs.forEach((end, start) => {
+      if (start !== 0) {
+        toggleCode('show', start + 1, end + 1);
+      }
+    });
+  };
 
   $('.collapser').on('click', function(elem) {
     let e = $(this);
@@ -93,4 +115,17 @@ $(function() {
       toggleCode('show', index + 1, pairs.get(index));
     }
   });
+  
+  $(document).on('keydown', (e) => {
+    if (window.location.hostname === 'github.com' && e.ctrlKey === true && e.shiftKey === true) {
+        if (plusKeys.indexOf(e.which) > -1) {
+			    e.preventDefault();
+			    unfoldAll();
+		    }
+		    else if (minusKeys.indexOf(e.which) > -1) {
+			    e.preventDefault();
+			    foldAll();
+		    }
+	    }
+    });
 });


### PR DESCRIPTION
Fold all suitable blocks (except the first one) using the combination of [CTRL Shift +];
Unfold all suitable blocks (except the first one) using the combination of [CTRL Shift -];
The [+] and [-] keys can be either those on the horizontal row of the keyboard or on the dedicated numpad, if it exists;
It prevents the built in zoom in/out functionality of the browser when pressing [CTRL Shift +] or [CTRL Shift -]